### PR TITLE
Fixed unused parameter warnings

### DIFF
--- a/Distribution/CodeMirrorView.m
+++ b/Distribution/CodeMirrorView.m
@@ -33,7 +33,7 @@
 
 @synthesize delegate=_delegate;
 
-- (void)webView:(WebView*)webView didClearWindowObject:(WebScriptObject*)windowObject forFrame:(WebFrame*)frame {
+- (void)webView:(WebView*) __unused webView didClearWindowObject:(WebScriptObject*)windowObject forFrame:(WebFrame*) __unused frame {
   [windowObject setValue:self forKey:@"_delegate"];
 }
 


### PR DESCRIPTION
Fixed compiler warnings with `__unused` where parameter is not used.
