### PR TITLE
Use class relative `NSBundle`

### DIFF
--- a/Distribution/CodeMirrorView.m
+++ b/Distribution/CodeMirrorView.m
@@ -45,7 +45,7 @@
     [self setAutoresizesSubviews:YES];
     [_webView setAutoresizingMask:(NSViewWidthSizable | NSViewHeightSizable)];
     
-    NSBundle* bundle = [NSBundle bundleWithPath:[[NSBundle mainBundle] pathForResource:@"CodeMirrorView" ofType:@"bundle"]];
+    NSBundle* bundle = [NSBundle bundleWithPath:[[NSBundle bundleForClass:[self class]] pathForResource:@"CodeMirrorView" ofType:@"bundle"]];
     NSData* data = [NSData dataWithContentsOfFile:[bundle pathForResource:@"index" ofType:@"html"]];
     if (data == nil) {
 #if !__has_feature(objc_arc)


### PR DESCRIPTION
Switched to `bundleForClass` to allow `CodeMirrorView` to be embedded
within a framework or non-application bundle.

At the moment `CodeMirrorView` assumes the `CodeMirrorView.bundle` will be present in the main bundle's resources. This may not be the case if the view is used within a framework, preference panel, or other non-app project. 
