### PR TITLE
Fix CFBundleShortVersionString

### DIFF
--- a/Bundle-Info.plist
+++ b/Bundle-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>net.codemirror.view</string>
 	<key>CFBundleShortVersionString</key>
-	<string>CodeMirror __VERSION__</string>
+	<string>__VERSION__</string>
 	<key>CFBundleVersion</key>
 	<string>__VERSION__</string>
 </dict>

--- a/Make_Bundle.sh
+++ b/Make_Bundle.sh
@@ -31,17 +31,18 @@ if [ $# != 1 ]; then
 fi
 VERSION="$1"
 
-ARCHIVE="CoreMirror.tar.gz"
+ARCHIVE="codemirror.zip"
 
 BUNDLE_PATH="Distribution/CodeMirrorView.bundle"
 CONTENTS_PATH="$BUNDLE_PATH/Contents"
 RESOURCES_PATH="$CONTENTS_PATH/Resources"
 
 rm -f "$ARCHIVE"
-curl -L -o "$ARCHIVE" "https://github.com/marijnh/CodeMirror/archive/$VERSION.tar.gz"
-tar -xf "$ARCHIVE"
+curl -L -o "$ARCHIVE" "https://codemirror.net/codemirror.zip"
+unzip "$ARCHIVE"
 rm -f "$ARCHIVE"
-mv -f "CodeMirror-$VERSION" "CodeMirror"
+
+mv -f "codemirror-$VERSION" "CodeMirror"
 
 rm -rf "$BUNDLE_PATH"
 mkdir -p "$RESOURCES_PATH"

--- a/Make_Bundle.sh
+++ b/Make_Bundle.sh
@@ -41,7 +41,6 @@ rm -f "$ARCHIVE"
 curl -L -o "$ARCHIVE" "https://codemirror.net/codemirror.zip"
 unzip "$ARCHIVE"
 rm -f "$ARCHIVE"
-
 mv -f "codemirror-$VERSION" "CodeMirror"
 
 rm -rf "$BUNDLE_PATH"


### PR DESCRIPTION
[CFBundleShortVersionString](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-111349) should be a string composed of three period-separated integers.